### PR TITLE
remove react strict mode

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -6,9 +6,7 @@ import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
     <App />
-  </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
Clicking on the links would update the url but wouldn't refresh the page. Removing <React.StrictMode> fixes this